### PR TITLE
Fix JSON syntax in action default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   extensions:
     description: "A JSON list of extensions to be passed to Python markdown"
     required: true
-    default: "['extra']"
+    default: '["extra"]'
   extension_configs:
     description: "A JSON object of extension configurations"
     required: true


### PR DESCRIPTION
The JSON default for `extensions` used single quotes instead of double quotes leading to an error if the default extensions were used:
```
Collecting markdown
  Downloading Markdown-3.3.3-py3-none-any.whl (96 kB)
Collecting natsort
  Downloading natsort-7.1.0-py3-none-any.whl (35 kB)
Installing collected packages: natsort, markdown
Successfully installed markdown-3.3.3 natsort-7.1.0
- Markdown-HTML -
Traceback (most recent call last):
  File "/markdown-html.py", line 12, in <module>
    EXTENSIONS : list = json.loads(os.environ['INPUT_EXTENSIONS'])
  File "/usr/local/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 2 (char 1)
```